### PR TITLE
fix: use map for custom roles

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,9 +1,9 @@
 locals {
-  clickhouse_custom_roles = [
-    google_project_iam_custom_role.clickhouse_common_role.id,
-    google_project_iam_custom_role.clickhouse_vpc_role.id,
-    google_project_iam_custom_role.clickhouse_cluster_role.id,
-    google_project_iam_custom_role.clickhouse_storage_role.id,
-    google_project_iam_custom_role.clickhouse_iam_role.id,
-  ]
+  clickhouse_custom_roles = {
+    common_role  = google_project_iam_custom_role.clickhouse_common_role.id
+    vpc_role     = google_project_iam_custom_role.clickhouse_vpc_role.id
+    cluster_role = google_project_iam_custom_role.clickhouse_cluster_role.id
+    storage_role = google_project_iam_custom_role.clickhouse_storage_role.id
+    iam_role     = google_project_iam_custom_role.clickhouse_iam_role.id
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "google_project_service" "cloud_resource_manager" {
 
 # Grant IAM roles to ClickHouse Management SA
 resource "google_project_iam_member" "clickhouse_sa_roles" {
-  for_each = toset(local.clickhouse_custom_roles)
+  for_each = local.clickhouse_custom_roles
 
   depends_on = [google_project_service.cloud_resource_manager]
   project    = var.project_id


### PR DESCRIPTION
to fix the following error in new environments

```
the "for_each" set includes values derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.
```